### PR TITLE
Update hero image to have hyperlink to personal website

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-<img src="https://i.imgur.com/MHsfol1.jpeg" width="100%">
+[<img src="https://i.imgur.com/MHsfol1.jpeg" width="100%">](https://rollison.dev)
 <h3 align="center">A passionate full-stack developer from Indianapolis, IN</h3>
 
 <p align="center">


### PR DESCRIPTION
At the moment, clicking the "Alec Rollison" hero image at the top of the readme takes you to the image url itself. This PR makes it so clicking the image takes you to https://rollison.dev

Hover/click the examples below to see the difference

Before:

<img src="https://i.imgur.com/MHsfol1.jpeg" width="100%">

After:

[<img src="https://i.imgur.com/MHsfol1.jpeg" width="100%">](https://rollison.dev)